### PR TITLE
feat: add step number to URL hash for bookmarking

### DIFF
--- a/src/SauerteigProvider.tsx
+++ b/src/SauerteigProvider.tsx
@@ -1,4 +1,5 @@
-import {useState, ReactNode, ReactElement, createContext} from 'react';
+import {useState, useEffect, ReactNode, ReactElement, createContext} from 'react';
+import {stepsData} from './data';
 
 interface ContextProps {
   currentStep: number;
@@ -6,10 +7,19 @@ interface ContextProps {
 }
 
 const localStorageKey = 'SauerteigStep';
-const storageItem = window.localStorage.getItem(localStorageKey);
+
+const getInitialStep = (): number => {
+  const hash = window.location.hash.slice(1);
+  const hashStep = parseInt(hash, 10);
+  if (!isNaN(hashStep) && hashStep >= 0 && hashStep <= stepsData.length) {
+    return hashStep;
+  }
+  const storageItem = window.localStorage.getItem(localStorageKey);
+  return Number(storageItem) || 0;
+};
 
 export const SauerteigContext = createContext<ContextProps>({
-  currentStep: Number(storageItem) || 0,
+  currentStep: 0,
   setCurrentStep: () => {},
 });
 
@@ -18,7 +28,25 @@ interface SauerteigProviderProps {
 }
 
 const SauerteigProvider = ({children}: SauerteigProviderProps) => {
-  const [currentStep, setCurrentStep] = useState(Number(storageItem) || 0);
+  const [currentStep, setCurrentStep] = useState(getInitialStep);
+
+  useEffect(() => {
+    window.location.hash = currentStep.toString();
+  }, [currentStep]);
+
+  useEffect(() => {
+    const handleHashChange = () => {
+      const hash = window.location.hash.slice(1);
+      const step = parseInt(hash, 10);
+      if (!isNaN(step) && step >= 0 && step <= stepsData.length) {
+        setCurrentStep(step);
+        window.localStorage.setItem(localStorageKey, step.toString());
+      }
+    };
+
+    window.addEventListener('hashchange', handleHashChange);
+    return () => window.removeEventListener('hashchange', handleHashChange);
+  }, []);
 
   const persistCurrentStep = (step: number): void => {
     setCurrentStep(step);


### PR DESCRIPTION
Closes #94

## Summary

- Syncs the current step with the URL hash (e.g. `#0`, `#1` ... `#6`) so users can bookmark or share a direct link to any step
- On load, a valid hash takes precedence over the localStorage value; falls back to localStorage if the hash is absent or out of range
- Browser back/forward navigation is supported via a `hashchange` listener

## Test plan

- [ ] Navigate through steps and verify the URL hash updates (e.g. `#1`, `#2`)
- [ ] Copy a step URL and open it in a new tab - it should land on the correct step
- [ ] Use the browser back/forward buttons and verify the step changes accordingly
- [ ] Open with no hash - should load from localStorage (or step 0)

---
_Generated by [Claude Code](https://claude.ai/code/session_01L15Dfok2575HkxbobZpJ1H)_