### PR TITLE
ci: deploy only on release publication

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,21 @@
+name: Deploy
+
+permissions: {}
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    name: Deploy latest image
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+      - name: Deploy
+        uses: ffflorian/actions/coolify-deploy@86a6f4fba506628f07585dcd4010e05f2396c25a
+        with:
+          domain: ${{ secrets.COOLIFY_DOMAIN }}
+          token: ${{ secrets.COOLIFY_TOKEN }}
+          uuid: ${{ secrets.COOLIFY_UUID }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,7 +4,8 @@ permissions: {}
 
 on:
   release:
-    types: [published]
+    types:
+      - published
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/lint_test_publish.yml
+++ b/.github/workflows/lint_test_publish.yml
@@ -7,7 +7,6 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
-  workflow_dispatch:
 
 jobs:
   lint_typescript:
@@ -72,8 +71,6 @@ jobs:
       contents: write
       packages: write
       issues: write
-    outputs:
-      new_release_published: ${{ steps.publish_release.outputs.new_release_published }}
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:
@@ -87,19 +84,3 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           git_author: 'ffflorian'
           git_email: 'git@ffflorian.de'
-
-  deploy:
-    name: Deploy latest image
-    runs-on: ubuntu-latest
-    needs: publish
-    if: |
-      github.event_name == 'workflow_dispatch' ||
-      (needs.publish.outputs.new_release_published == 'true' && github.event_name == 'push' && github.ref == 'refs/heads/main')
-    permissions: {}
-    steps:
-      - name: Deploy
-        uses: ffflorian/actions/coolify-deploy@86a6f4fba506628f07585dcd4010e05f2396c25a
-        with:
-          domain: ${{ secrets.COOLIFY_DOMAIN }}
-          token: ${{ secrets.COOLIFY_TOKEN }}
-          uuid: ${{ secrets.COOLIFY_UUID }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,7 +113,8 @@ index.html             # HTML entry point
 
 ## CI/CD
 
-- **build_test_publish.yml**: runs lint → test → build on every push/PR to `main`; deploys to GitHub Pages (`gh-pages` branch) on `main` merges.
+- **lint_test_publish.yml**: runs lint → test → publish (Semantic Release + Docker image) on push/PR to `main`.
+- **deploy.yml**: deploys to production on GitHub release publication; also triggerable manually via `workflow_dispatch`.
 - **codeql.yml**: CodeQL security analysis on push/PR to `main` and weekly.
 - **yarn_update.yml**: monthly automated yarn update PR.
 - **dependabot.yml**: automated dependency version updates.


### PR DESCRIPTION
## Summary

- Extract the deploy step into a dedicated `deploy.yml` workflow triggered by `release: types: [published]` (GitHub release publication), with `workflow_dispatch` for manual runs
- Remove the `deploy` job and `workflow_dispatch` trigger from `lint_test_publish.yml`, which now only handles lint/test/publish on push and PRs to `main`
- Remove the unused `outputs` block from the `publish` job
- Update AGENTS.md CI/CD section to reflect the new workflow layout

## Test plan

- [ ] Verify `lint_test_publish.yml` no longer triggers a deploy on push to `main`
- [ ] Verify `deploy.yml` triggers when a GitHub release is published (Semantic Release creates one after each versioned push to `main`)
- [ ] Verify `deploy.yml` can be triggered manually via `workflow_dispatch`

---
_Generated by [Claude Code](https://claude.ai/code/session_01TnuYefiKMkRBn17GsATM67)_