### PR TITLE
feat: add checkboxes with wavy strikethrough to recipe steps

### DIFF
--- a/src/Content.tsx
+++ b/src/Content.tsx
@@ -4,7 +4,7 @@ import {useSwipeable} from 'react-swipeable';
 import {Introduction} from './Introduction';
 import {stepsData} from './data';
 import {Step} from './Step';
-import {SauerteigContext} from './SauerteigProvider';
+import {SauerteigContext} from './SauerteigContext';
 
 type Theme = 'dark' | 'light';
 const themeStorageKey = 'SauerteigTheme';
@@ -108,7 +108,7 @@ export const Content = () => {
           )}
         </button>
       </div>
-      {currentStep === 0 ? <Introduction /> : <Step stepNumber={currentStep} />}
+      {currentStep === 0 ? <Introduction /> : <Step key={currentStep} stepNumber={currentStep} />}
       <div className="navigation">
         {canGoBack && (
           <span className="previous" onClick={() => goBack()}>

--- a/src/Introduction.tsx
+++ b/src/Introduction.tsx
@@ -1,10 +1,13 @@
-import {useContext} from 'react';
+import {useState, useContext} from 'react';
 import {introductionData, stepsData} from './data';
-import {SauerteigContext} from './SauerteigProvider';
+import {SauerteigContext} from './SauerteigContext';
 
 export const Introduction = () => {
   const {setCurrentStep} = useContext(SauerteigContext);
   const {ingredients, title} = introductionData;
+  const [checkedIngredients, setCheckedIngredients] = useState<boolean[]>(() => ingredients.map(() => false));
+
+  const toggleIngredient = (index: number) => setCheckedIngredients(prev => prev.map((v, i) => (i === index ? !v : v)));
 
   return (
     <div className="part">
@@ -23,9 +26,14 @@ export const Introduction = () => {
       </div>
       <h2>{title}</h2>
       Benötigt werden:
-      <ul>
+      <ul className="checklist">
         {ingredients.map((ingredient, index) => (
-          <li key={index}>{ingredient}</li>
+          <li key={index} className={checkedIngredients[index] ? 'checked' : ''}>
+            <label className="checklist-label">
+              <input type="checkbox" checked={checkedIngredients[index]} onChange={() => toggleIngredient(index)} />
+              <span>{ingredient}</span>
+            </label>
+          </li>
         ))}
       </ul>
     </div>

--- a/src/SauerteigContext.ts
+++ b/src/SauerteigContext.ts
@@ -1,0 +1,11 @@
+import {createContext} from 'react';
+
+interface ContextProps {
+  currentStep: number;
+  setCurrentStep: (step: number) => void;
+}
+
+export const SauerteigContext = createContext<ContextProps>({
+  currentStep: 0,
+  setCurrentStep: () => {},
+});

--- a/src/SauerteigProvider.tsx
+++ b/src/SauerteigProvider.tsx
@@ -1,10 +1,6 @@
-import {useState, useEffect, ReactNode, ReactElement, createContext} from 'react';
+import {useState, useEffect, ReactNode, ReactElement} from 'react';
 import {stepsData} from './data';
-
-interface ContextProps {
-  currentStep: number;
-  setCurrentStep: (step: number) => void;
-}
+import {SauerteigContext} from './SauerteigContext';
 
 const localStorageKey = 'SauerteigStep';
 
@@ -17,11 +13,6 @@ const getInitialStep = (): number => {
   const storageItem = window.localStorage.getItem(localStorageKey);
   return Number(storageItem) || 0;
 };
-
-export const SauerteigContext = createContext<ContextProps>({
-  currentStep: 0,
-  setCurrentStep: () => {},
-});
 
 interface SauerteigProviderProps {
   children: ReactNode | ReactElement;

--- a/src/Step.tsx
+++ b/src/Step.tsx
@@ -1,3 +1,4 @@
+import {useState} from 'react';
 import {formatDistance, addMinutes} from 'date-fns';
 import {de as deLocale} from 'date-fns/locale/de';
 
@@ -8,13 +9,19 @@ export interface StepProps {
 }
 
 export const Step = ({stepNumber}: StepProps) => {
-  const {ingredients, manualTime, steps, subtitle, title, additionalInfo} = stepsData[stepNumber - 1];
+  const {ingredients, manualTime, steps, subtitle, title, additionalInfo, importantInfo} = stepsData[stepNumber - 1];
+  const [checkedSteps, setCheckedSteps] = useState<boolean[]>(() => steps.map(() => false));
+  const [checkedIngredients, setCheckedIngredients] = useState<boolean[]>(() => ingredients.map(() => false));
+
   const accumulatedCountdownMinutes = stepsData
     .slice(stepNumber - 1)
     .reduce((result, step) => result + step.otherTime + step.manualTime, 0);
   const countdownText = formatDistance(new Date(), addMinutes(new Date(), accumulatedCountdownMinutes), {
     locale: deLocale,
   });
+
+  const toggleStep = (index: number) => setCheckedSteps(prev => prev.map((v, i) => (i === index ? !v : v)));
+  const toggleIngredient = (index: number) => setCheckedIngredients(prev => prev.map((v, i) => (i === index ? !v : v)));
 
   return (
     <div className="part">
@@ -31,20 +38,35 @@ export const Step = ({stepNumber}: StepProps) => {
       {!!ingredients.length && (
         <>
           <h3>Zutaten</h3>
-          <ul>
+          <ul className="checklist">
             {ingredients.map((ingredient, index) => (
-              <li key={index}>{ingredient}</li>
+              <li key={index} className={checkedIngredients[index] ? 'checked' : ''}>
+                <label className="checklist-label">
+                  <input type="checkbox" checked={checkedIngredients[index]} onChange={() => toggleIngredient(index)} />
+                  <span>{ingredient}</span>
+                </label>
+              </li>
             ))}
           </ul>
         </>
       )}
       <h3>Zubereitung</h3>
-      <ol>
+      <ol className="checklist">
         {steps.map((step, index) => (
-          <li key={index}>{step}</li>
+          <li key={index} className={checkedSteps[index] ? 'checked' : ''}>
+            <label className="checklist-label">
+              <input type="checkbox" checked={checkedSteps[index]} onChange={() => toggleStep(index)} />
+              <span>{step}</span>
+            </label>
+          </li>
         ))}
       </ol>
       {additionalInfo && <div>{additionalInfo.join(' ')}</div>}
+      {importantInfo && (
+        <div>
+          <strong>Wichtig:</strong> {importantInfo}
+        </div>
+      )}
     </div>
   );
 };

--- a/src/data.ts
+++ b/src/data.ts
@@ -2,6 +2,7 @@ export type IntroductionProps = Pick<StepData, 'ingredients' | 'title'>;
 
 export interface StepData {
   additionalInfo?: string[];
+  importantInfo?: string;
   ingredients: string[];
   /** the time in minutes to work on the current step */
   manualTime: number;
@@ -67,7 +68,7 @@ export const stepsData: StepData[] = [
     title: 'Bereit machen zum backen',
   },
   {
-    additionalInfo: ['Wichtig: alle 1-2 Tage füttern, sonst verhungert der Anstellsauer.'],
+    importantInfo: 'alle 1-2 Tage füttern, sonst verhungert der Anstellsauer.',
     ingredients: [
       'ein luftdicht verschließbares Gefäß (z.B. ein gut gespültes Gurkenglas), das nicht zu klein ist, denn der Anstellsauer wächst',
       '2 EL kaltes Wasser',

--- a/src/index.css
+++ b/src/index.css
@@ -205,6 +205,54 @@ li {
   float: none;
 }
 
+ul.checklist {
+  list-style: none;
+  padding-left: 0;
+}
+
+.checklist-label {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  cursor: pointer;
+}
+
+.checklist-label input[type='checkbox'] {
+  appearance: none;
+  -webkit-appearance: none;
+  flex-shrink: 0;
+  width: 1.05rem;
+  height: 1.05rem;
+  margin-top: 0.3rem;
+  border: 1.5px solid var(--color-border);
+  border-radius: 4px;
+  background-color: var(--color-surface);
+  cursor: pointer;
+  position: relative;
+  transition:
+    background-color 0.15s,
+    border-color 0.15s;
+}
+
+.checklist-label input[type='checkbox']:hover {
+  border-color: var(--color-accent);
+}
+
+.checklist-label input[type='checkbox']:checked {
+  background-color: var(--color-accent);
+  border-color: var(--color-accent);
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 12'%3E%3Cpath d='M2 6l3 3 5-5' stroke='white' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round' fill='none'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: center;
+  background-size: 75%;
+}
+
+li.checked .checklist-label span {
+  text-decoration: line-through wavy;
+  text-decoration-color: var(--color-accent);
+  color: color-mix(in srgb, var(--color-text-muted) 50%, transparent);
+}
+
 .footer {
   margin-top: 56px;
   padding-top: 20px;


### PR DESCRIPTION
## Summary

- Add interactive checkboxes to ingredients and preparation steps on all pages (Introduction + all Step pages)
- Checked items are struck through with a wavy line; text fades using `color-mix` so the line stays fully visible
- Custom-styled checkbox matches the page theme: `--color-border` outline, `--color-accent` fill, SVG checkmark on checked, hover state
- Checkbox state resets on step navigation via `key={currentStep}` on the `Step` component
- Extract `SauerteigContext` to its own file (`SauerteigContext.ts`) to fix Vite Fast Refresh HMR incompatibility warning
- Add `importantInfo` field to `StepData`; rendered with a hardcoded bold `Wichtig:` prefix, separate from `additionalInfo`

## Test plan

- [ ] Check off ingredients and steps on the Introduction page
- [ ] Navigate to a step, check some items, navigate away and back — state should reset
- [ ] Verify wavy strikethrough is visible and text is faded on checked items
- [ ] Verify "Wichtig:" is bold on step 4 (Neuer Anstellsauer)
- [ ] Verify light and dark mode both look correct
- [ ] Check no HMR warnings in the browser console on file save