### PR TITLE
feat: add per-step reminder timers and persist checkbox state

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,7 @@ This file explains how coding agents should work in this repository.
 - No docstrings or type annotations on code not being changed.
 - No error handling for scenarios that cannot happen.
 - Three similar lines is better than a premature abstraction.
+- Always use curly braces for `if` statements, even single-line ones.
 
 ### Review Rules
 

--- a/Rezept.md
+++ b/Rezept.md
@@ -105,7 +105,7 @@ Man nehme:
 1. Das Mehl, Wasser und Salz zum restlichen Anstellsauer hinzufügen
 2. Ggf. die Kerne hinzufügen
 3. 12 Min. verkneten (am besten mit einem Holzlöffel oder einer Kitchen Aid)
-4. Mit einem Küchenhandtuch abdecken 30 Min. gehen lassen
+4. Mit einem Küchenhandtuch abdecken und 30 Min. gehen lassen
 5. Brotform mit Backpapier auslegen
 6. Nicht abdecken (sonst wächst der Teig über die Form hinaus) und 2 Std. gehen lassen
 

--- a/src/ReminderTimer.tsx
+++ b/src/ReminderTimer.tsx
@@ -14,6 +14,9 @@ function labelForMinutes(minutes: number): string {
 }
 
 function labelForRemaining(ms: number): string {
+  if (ms < 1000) {
+    return formatDuration({seconds: 1}, {locale: deLocale});
+  }
   return formatDuration(intervalToDuration({start: 0, end: ms}), {
     locale: deLocale,
     format: ['hours', 'minutes', 'seconds'],

--- a/src/ReminderTimer.tsx
+++ b/src/ReminderTimer.tsx
@@ -1,0 +1,119 @@
+import {useState, useEffect} from 'react';
+import {formatDuration, intervalToDuration} from 'date-fns';
+import {de as deLocale} from 'date-fns/locale/de';
+
+interface ReminderTimerProps {
+  disabled?: boolean;
+  minutes: number;
+  onExpire?: () => void;
+  storageKey: string;
+}
+
+function labelForMinutes(minutes: number): string {
+  return formatDuration(intervalToDuration({start: 0, end: minutes * 60 * 1000}), {locale: deLocale});
+}
+
+function labelForRemaining(ms: number): string {
+  return formatDuration(intervalToDuration({start: 0, end: ms}), {
+    locale: deLocale,
+    format: ['hours', 'minutes', 'seconds'],
+  });
+}
+
+export const ReminderTimer = ({disabled, minutes, onExpire, storageKey}: ReminderTimerProps) => {
+  const [endTime, setEndTime] = useState<number | null>(() => {
+    const stored = localStorage.getItem(storageKey);
+    return stored ? parseInt(stored, 10) : null;
+  });
+  const [remaining, setRemaining] = useState<number | null>(null);
+  const [permission, setPermission] = useState<NotificationPermission>(
+    typeof Notification !== 'undefined' ? Notification.permission : 'denied'
+  );
+
+  useEffect(() => {
+    if (!disabled || endTime === null) {
+      return;
+    }
+    const id = setTimeout(() => {
+      localStorage.removeItem(storageKey);
+      setEndTime(null);
+      setRemaining(null);
+    }, 0);
+    return () => clearTimeout(id);
+  }, [disabled, endTime, storageKey]);
+
+  useEffect(() => {
+    if (!endTime || disabled) {
+      return;
+    }
+
+    const tick = () => {
+      const diff = endTime - Date.now();
+      if (diff <= 0) {
+        if (Notification.permission === 'granted') {
+          new Notification('Sauerteig-Erinnerung', {
+            body: `Die Wartezeit von ${labelForMinutes(minutes)} ist abgelaufen!`,
+          });
+        }
+        localStorage.removeItem(storageKey);
+        setEndTime(null);
+        setRemaining(null);
+        onExpire?.();
+      } else {
+        setRemaining(diff);
+      }
+    };
+
+    const immediateId = setTimeout(tick, 0);
+    const intervalId = setInterval(tick, 1000);
+
+    return () => {
+      clearTimeout(immediateId);
+      clearInterval(intervalId);
+    };
+  }, [endTime, storageKey, minutes, onExpire, disabled]);
+
+  const startTimer = async () => {
+    if (typeof Notification === 'undefined') {
+      return;
+    }
+    let perm = permission;
+    if (perm === 'default') {
+      perm = await Notification.requestPermission();
+      setPermission(perm);
+    }
+    if (perm === 'denied') {
+      return;
+    }
+    const end = Date.now() + minutes * 60 * 1000;
+    localStorage.setItem(storageKey, String(end));
+    setEndTime(end);
+  };
+
+  const cancel = () => {
+    localStorage.removeItem(storageKey);
+    setEndTime(null);
+    setRemaining(null);
+  };
+
+  if (permission === 'denied') {
+    return null;
+  }
+
+  if (endTime !== null && remaining !== null && !disabled) {
+    return (
+      <div className="reminder-timer reminder-timer--active">
+        <span>🕐 Noch {labelForRemaining(remaining)}</span>
+        <button className="reminder-cancel" onClick={cancel}>
+          Abbrechen
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <button className="reminder-timer" onClick={startTimer} disabled={disabled}>
+      🕐 Erinnere mich in {labelForMinutes(minutes)}
+    </button>
+  );
+};

--- a/src/Step.tsx
+++ b/src/Step.tsx
@@ -3,15 +3,42 @@ import {formatDistance, addMinutes} from 'date-fns';
 import {de as deLocale} from 'date-fns/locale/de';
 
 import {stepsData} from './data';
+import {ReminderTimer} from './ReminderTimer';
 
 export interface StepProps {
   stepNumber: number;
 }
 
 export const Step = ({stepNumber}: StepProps) => {
-  const {ingredients, manualTime, steps, subtitle, title, additionalInfo, importantInfo} = stepsData[stepNumber - 1];
-  const [checkedSteps, setCheckedSteps] = useState<boolean[]>(() => steps.map(() => false));
-  const [checkedIngredients, setCheckedIngredients] = useState<boolean[]>(() => ingredients.map(() => false));
+  const {
+    id: stepId,
+    ingredients,
+    manualTime,
+    steps,
+    subtitle,
+    title,
+    additionalInfo,
+    importantInfo,
+  } = stepsData[stepNumber - 1];
+
+  const [checkedSteps, setCheckedSteps] = useState<boolean[]>(() =>
+    steps.map(step => localStorage.getItem(`SauerteigStep_${step.id}`) === 'true')
+  );
+
+  const [checkedIngredients, setCheckedIngredients] = useState<boolean[]>(() => {
+    const raw = localStorage.getItem(`SauerteigIngredients_${stepId}`);
+    if (raw !== null) {
+      try {
+        const stored = JSON.parse(raw) as boolean[] | null;
+        if (Array.isArray(stored) && stored.length === ingredients.length) {
+          return stored;
+        }
+      } catch {
+        return ingredients.map(() => false);
+      }
+    }
+    return ingredients.map(() => false);
+  });
 
   const accumulatedCountdownMinutes = stepsData
     .slice(stepNumber - 1)
@@ -20,8 +47,21 @@ export const Step = ({stepNumber}: StepProps) => {
     locale: deLocale,
   });
 
-  const toggleStep = (index: number) => setCheckedSteps(prev => prev.map((v, i) => (i === index ? !v : v)));
-  const toggleIngredient = (index: number) => setCheckedIngredients(prev => prev.map((v, i) => (i === index ? !v : v)));
+  const toggleStep = (index: number) => {
+    setCheckedSteps(prev => {
+      const next = prev.map((v, i) => (i === index ? !v : v));
+      localStorage.setItem(`SauerteigStep_${steps[index].id}`, String(next[index]));
+      return next;
+    });
+  };
+
+  const toggleIngredient = (index: number) => {
+    setCheckedIngredients(prev => {
+      const next = prev.map((v, i) => (i === index ? !v : v));
+      localStorage.setItem(`SauerteigIngredients_${stepId}`, JSON.stringify(next));
+      return next;
+    });
+  };
 
   return (
     <div className="part">
@@ -53,11 +93,21 @@ export const Step = ({stepNumber}: StepProps) => {
       <h3>Zubereitung</h3>
       <ol className="checklist">
         {steps.map((step, index) => (
-          <li key={index} className={checkedSteps[index] ? 'checked' : ''}>
+          <li key={step.id} className={checkedSteps[index] ? 'checked' : ''}>
             <label className="checklist-label">
               <input type="checkbox" checked={checkedSteps[index]} onChange={() => toggleStep(index)} />
-              <span>{step}</span>
+              <span>{step.text}</span>
             </label>
+            {step.timerMinutes !== undefined && (
+              <div className="step-timer">
+                <ReminderTimer
+                  disabled={checkedSteps[index]}
+                  minutes={step.timerMinutes}
+                  onExpire={() => toggleStep(index)}
+                  storageKey={`SauerteigTimer_${step.id}`}
+                />
+              </div>
+            )}
           </li>
         ))}
       </ol>

--- a/src/data.ts
+++ b/src/data.ts
@@ -123,7 +123,7 @@ export const stepsData: StepData[] = [
         text: '12 Min. verkneten (am besten mit einem Holzlöffel oder einer Kitchen Aid)',
         timerMinutes: 12,
       },
-      {id: 'n8w6x', text: 'Mit einem Küchenhandtuch abdecken 30 Min. gehen lassen', timerMinutes: 30},
+      {id: 'n8w6x', text: 'Mit einem Küchenhandtuch abdecken und 30 Min. gehen lassen', timerMinutes: 30},
       {id: 'c1m4k', text: 'Brotform mit Backpapier auslegen'},
       {
         id: 'd7z9p',

--- a/src/data.ts
+++ b/src/data.ts
@@ -2,15 +2,22 @@ export type IntroductionProps = Pick<StepData, 'ingredients' | 'title'>;
 
 export interface StepData {
   additionalInfo?: string[];
+  id: string;
   importantInfo?: string;
   ingredients: string[];
   /** the time in minutes to work on the current step */
   manualTime: number;
   /** the time in minutes to finish the current step */
   otherTime: number;
-  steps: string[];
+  steps: StepItem[];
   subtitle?: string;
   title: string;
+}
+
+export interface StepItem {
+  id: string;
+  text: string;
+  timerMinutes?: number;
 }
 
 export const introductionData: IntroductionProps = {
@@ -32,16 +39,21 @@ export const introductionData: IntroductionProps = {
 
 export const stepsData: StepData[] = [
   {
+    id: 'xk7p2',
     ingredients: ['400 ml lauwarmes Wasser', '250 g Roggenvollkornmehl', 'Frischhaltefolie', 'mittelgroße Schüssel'],
     manualTime: 15,
     otherTime: 5760,
     steps: [
-      '200 ml Wasser mit 160 g Mehl in der Schüssel vermengen',
-      'Schüssel mit Frischhaltefolie abdecken und 48 Std. bei Zimmertemperatur ruhen lassen',
-      '100 ml Wasser und 45 g Mehl dazu mischen',
-      'Abdecken und 24 Std. ruhen lassen',
-      '100 ml Wasser und 45 g Mehl dazu mischen',
-      'Abdecken und weitere 24 Std. ruhen lassen',
+      {id: 'a3r7x', text: '200 ml Wasser mit 160 g Mehl in der Schüssel vermengen'},
+      {
+        id: 'k9m2p',
+        text: 'Schüssel mit Frischhaltefolie abdecken und 48 Std. bei Zimmertemperatur ruhen lassen',
+        timerMinutes: 2880,
+      },
+      {id: 'z4v6n', text: '100 ml Wasser und 45 g Mehl dazu mischen'},
+      {id: 'y8c1w', text: 'Abdecken und 24 Std. ruhen lassen', timerMinutes: 1440},
+      {id: 'h5j3q', text: '100 ml Wasser und 45 g Mehl dazu mischen'},
+      {id: 'f7t9s', text: 'Abdecken und weitere 24 Std. ruhen lassen', timerMinutes: 1440},
     ],
     title: 'Grundrezept (Anstellsauer)',
   },
@@ -50,24 +62,34 @@ export const stepsData: StepData[] = [
       'Dies im Abstand von 6-8 Std. 3x wiederholen und dazwischen mit einem Küchenhandtuch abgedeckt an einem warmen Ort ruhen lassen.',
       'Dieser Schritt kann auch mehr als 3x wiederholt werden, wenn das Brot später als geplant gebacken werden soll.',
     ],
+    id: 'm4n9r',
     ingredients: ['2 EL lauwarmes Wasser', '1 EL Roggen(vollkorn)mehl', '1 große Schüssel'],
     manualTime: 20,
     otherTime: 1320,
-    steps: ['Anstellsauer in die Schüssel umfüllen', 'Wasser und Mehl hinzufügen und verrühren'],
+    steps: [
+      {id: 'e2u4b', text: 'Anstellsauer in die Schüssel umfüllen'},
+      {id: 'i6o8d', text: 'Wasser und Mehl hinzufügen und verrühren'},
+    ],
     subtitle: '(hier starten, wenn Anstellsauer schon vorhanden ist)',
     title: 'Füttern',
   },
   {
+    id: 'q1t5v',
     ingredients: ['350 g Roggen(vollkorn)mehl', '500 ml warmes Wasser'],
     manualTime: 5,
     otherTime: 720,
     steps: [
-      'Wasser und Mehl mit dem Teig verrühren',
-      '12 Stunden mit einem Küchenhandtuch abgedeckt an einem warmen Ort ruhen lassen',
+      {id: 'r1x5k', text: 'Wasser und Mehl mit dem Teig verrühren'},
+      {
+        id: 'g9n3m',
+        text: '12 Stunden mit einem Küchenhandtuch abgedeckt an einem warmen Ort ruhen lassen',
+        timerMinutes: 720,
+      },
     ],
     title: 'Bereit machen zum backen',
   },
   {
+    id: 'l8w3z',
     importantInfo: 'alle 1-2 Tage füttern, sonst verhungert der Anstellsauer.',
     ingredients: [
       'ein luftdicht verschließbares Gefäß (z.B. ein gut gespültes Gurkenglas), das nicht zu klein ist, denn der Anstellsauer wächst',
@@ -77,13 +99,14 @@ export const stepsData: StepData[] = [
     manualTime: 5,
     otherTime: 0,
     steps: [
-      '50-100 ml Anstellsauer abnehmen und in das Gefäß füllen',
-      'Das Wasser und Roggenmehl hinzufügen, vermischen und das Gefäß luftdicht verschließen',
-      'Das Gefäß mit Anstellsauer in den Kühlschrank stellen',
+      {id: 'w7p4z', text: '50-100 ml Anstellsauer abnehmen und in das Gefäß füllen'},
+      {id: 'v2c8y', text: 'Das Wasser und Roggenmehl hinzufügen, vermischen und das Gefäß luftdicht verschließen'},
+      {id: 's6h1j', text: 'Das Gefäß mit Anstellsauer in den Kühlschrank stellen'},
     ],
     title: 'Neuer Anstellsauer',
   },
   {
+    id: 'b6f0j',
     ingredients: [
       '250 ml warmes Wasser',
       '500 g Dinkelmehl (anderes Mehl geht auch, aber Dinkelmehl macht das Brot saftig)',
@@ -93,25 +116,37 @@ export const stepsData: StepData[] = [
     manualTime: 15,
     otherTime: 150,
     steps: [
-      'Das Mehl, Wasser und Salz zum restlichen Anstellsauer hinzufügen',
-      'Ggf. die Kerne hinzufügen',
-      '12 Min. verkneten (am besten mit einem Holzlöffel oder einer Kitchen Aid)',
-      'Mit einem Küchenhandtuch abdecken 30 Min. gehen lassen',
-      'Brotform mit Backpapier auslegen',
-      'Nicht abdecken (sonst wächst der Teig über die Form hinaus) und 2 Std. gehen lassen',
+      {id: 'b4f9t', text: 'Das Mehl, Wasser und Salz zum restlichen Anstellsauer hinzufügen'},
+      {id: 'u3r7a', text: 'Ggf. die Kerne hinzufügen'},
+      {
+        id: 'o5q2e',
+        text: '12 Min. verkneten (am besten mit einem Holzlöffel oder einer Kitchen Aid)',
+        timerMinutes: 12,
+      },
+      {id: 'n8w6x', text: 'Mit einem Küchenhandtuch abdecken 30 Min. gehen lassen', timerMinutes: 30},
+      {id: 'c1m4k', text: 'Brotform mit Backpapier auslegen'},
+      {
+        id: 'd7z9p',
+        text: 'Nicht abdecken (sonst wächst der Teig über die Form hinaus) und 2 Std. gehen lassen',
+        timerMinutes: 120,
+      },
     ],
     title: 'Teigherstellung',
   },
   {
+    id: 'd2h4s',
     ingredients: [],
     manualTime: 5,
     otherTime: 55,
     steps: [
-      'Backofen auf 200 °C Ober- und Unterhitze vorheizen',
-      'Ggf. Brot mit einem nassen Messer in der Mitte einschneiden',
-      'Bei 200 °C Ober- und Unterhitze 15 Min. backen (untere Schiene)',
-      'Bei 220 °C Ober- und Unterhitze 40 Min. backen (untere Schiene)',
-      'Nach dem Backen sofort aus der Form nehmen, das Backpapier abziehen und das Brot abkühlen lassen  ',
+      {id: 'j5v3b', text: 'Backofen auf 200 °C Ober- und Unterhitze vorheizen'},
+      {id: 'l8u1r', text: 'Ggf. Brot mit einem nassen Messer in der Mitte einschneiden'},
+      {id: 'q4s7n', text: 'Bei 200 °C Ober- und Unterhitze 15 Min. backen (untere Schiene)', timerMinutes: 15},
+      {id: 'h2g6f', text: 'Bei 220 °C Ober- und Unterhitze 40 Min. backen (untere Schiene)', timerMinutes: 40},
+      {
+        id: 'y9t5c',
+        text: 'Nach dem Backen sofort aus der Form nehmen, das Backpapier abziehen und das Brot abkühlen lassen',
+      },
     ],
     title: 'Backen',
   },

--- a/src/index.css
+++ b/src/index.css
@@ -253,6 +253,62 @@ li.checked .checklist-label span {
   color: color-mix(in srgb, var(--color-text-muted) 50%, transparent);
 }
 
+.step-timer {
+  padding-left: calc(1.05rem + 10px);
+  padding-top: 4px;
+  padding-bottom: 2px;
+}
+
+.reminder-timer {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  background: none;
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  padding: 6px 12px;
+  font-size: 0.9rem;
+  color: var(--color-link);
+  cursor: pointer;
+  transition:
+    background-color 0.15s,
+    border-color 0.15s;
+}
+
+.reminder-timer:hover:not(:disabled) {
+  background-color: var(--color-border);
+}
+
+.reminder-timer:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.reminder-timer--active {
+  cursor: default;
+  color: var(--color-text-muted);
+  border-color: var(--color-border);
+}
+
+.reminder-timer--active:hover {
+  background-color: transparent;
+}
+
+.reminder-cancel {
+  background: none;
+  border: none;
+  padding: 0;
+  margin-left: 6px;
+  font-size: 0.8rem;
+  color: var(--color-text-muted);
+  cursor: pointer;
+  text-decoration: underline;
+}
+
+.reminder-cancel:hover {
+  color: var(--color-accent);
+}
+
 .footer {
   margin-top: 56px;
   padding-top: 20px;


### PR DESCRIPTION
## Summary

- Adds a `ReminderTimer` component that appears below each Zubereitung step mentioning a wait time (e.g. \"48 Std.\", \"30 Min.\"). Clicking it requests notification permission, starts a countdown, and fires a browser notification on expiry. The end timestamp is persisted to `localStorage` so the timer survives page reloads.
- Timer expiry auto-checks the corresponding step checkbox.
- Checking a step while its timer is running stops the timer immediately (interval torn down, localStorage cleared); the button renders greyed out and disabled.
- All step and ingredient checkbox state is persisted to `localStorage` using stable per-item IDs instead of fragile index-based keys.
- Each `StepData` and `StepItem` now carries a unique 5-char random ID used as the `localStorage` key prefix.

This closes https://github.com/ffflorian/sauerteig/issues/6 🎉 