### PR TITLE
feat: make app installable as PWA and prompt iOS users to install

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
     <meta name="theme-color" content="#000000" />
     <meta name="description" content="Backe das beste Sauerteigbrot." />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+    <meta name="apple-mobile-web-app-title" content="Sauerteig" />
+    <link rel="apple-touch-icon" href="%BASE_URL%img/sauerteig_192.png" />
     <meta property="og:image" content="%BASE_URL%img/sauerteig_256.png" />
     <meta property="og:title" content="Sauerteig" />
     <meta property="og:type" content="website" />

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,8 +1,40 @@
 {
   "short_name": "Sauerteig",
-  "name": "Bake the best sour dough bread.",
+  "name": "Sauerteig - Backe das beste Sauerteigbrot",
+  "description": "Backe das beste Sauerteigbrot.",
   "start_url": ".",
+  "scope": ".",
   "display": "standalone",
+  "orientation": "portrait",
   "theme_color": "#000000",
-  "background_color": "#ffffff"
+  "background_color": "#f8f4ef",
+  "icons": [
+    {
+      "src": "img/sauerteig_96.png",
+      "sizes": "96x96",
+      "type": "image/png"
+    },
+    {
+      "src": "img/sauerteig_128.png",
+      "sizes": "128x128",
+      "type": "image/png"
+    },
+    {
+      "src": "img/sauerteig_192.png",
+      "sizes": "192x192",
+      "type": "image/png",
+      "purpose": "any maskable"
+    },
+    {
+      "src": "img/sauerteig_256.png",
+      "sizes": "256x256",
+      "type": "image/png"
+    },
+    {
+      "src": "img/sauerteig_512.png",
+      "sizes": "512x512",
+      "type": "image/png",
+      "purpose": "any maskable"
+    }
+  ]
 }

--- a/src/InstallPrompt.tsx
+++ b/src/InstallPrompt.tsx
@@ -1,0 +1,58 @@
+import {createPortal} from 'react-dom';
+
+interface InstallPromptProps {
+  onClose: () => void;
+}
+
+const ShareIcon = () => (
+  <svg
+    className="install-prompt-share-icon"
+    width="18"
+    height="18"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden="true"
+  >
+    <path d="M12 3v12" />
+    <path d="m8 7 4-4 4 4" />
+    <path d="M5 12v7a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2v-7" />
+  </svg>
+);
+
+export const InstallPrompt = ({onClose}: InstallPromptProps) => {
+  return createPortal(
+    <div className="install-prompt-overlay" onClick={onClose}>
+      <div
+        className="install-prompt"
+        role="dialog"
+        aria-modal="true"
+        aria-label="App installieren"
+        onClick={event => event.stopPropagation()}
+      >
+        <img className="install-prompt-icon" src="img/sauerteig_128.png" alt="" />
+        <h2 className="install-prompt-title">Benachrichtigungen aktivieren</h2>
+        <p className="install-prompt-text">
+          Dein Timer läuft jetzt in der App. Damit du auch benachrichtigt wirst, wenn er abläuft, füge Sauerteig zu
+          deinem Home-Bildschirm hinzu.
+        </p>
+        <ol className="install-prompt-steps">
+          <li>
+            Tippe unten auf <ShareIcon /> <strong>Teilen</strong>.
+          </li>
+          <li>
+            Wähle <strong>Zum Home-Bildschirm</strong>.
+          </li>
+          <li>Öffne Sauerteig künftig über das neue Symbol.</li>
+        </ol>
+        <button className="install-prompt-close" onClick={onClose}>
+          Verstanden
+        </button>
+      </div>
+    </div>,
+    document.body
+  );
+};

--- a/src/ReminderTimer.tsx
+++ b/src/ReminderTimer.tsx
@@ -2,6 +2,9 @@ import {useState, useEffect} from 'react';
 import {formatDuration, intervalToDuration} from 'date-fns';
 import {de as deLocale} from 'date-fns/locale/de';
 
+import {InstallPrompt} from './InstallPrompt';
+import {shouldSuggestInstall} from './iosPwa';
+
 interface ReminderTimerProps {
   disabled?: boolean;
   minutes: number;
@@ -11,6 +14,9 @@ interface ReminderTimerProps {
 
 // iOS Safari (outside the installed PWA) does not expose the Notification API.
 const notificationsSupported = typeof Notification !== 'undefined';
+
+// Once dismissed, do not nag the user with the install hint on every timer.
+const installPromptDismissedKey = 'SauerteigInstallPromptDismissed';
 
 function labelForMinutes(minutes: number): string {
   return formatDuration(intervalToDuration({start: 0, end: minutes * 60 * 1000}), {locale: deLocale}).replace(
@@ -38,6 +44,7 @@ export const ReminderTimer = ({disabled, minutes, onExpire, storageKey}: Reminde
   const [permission, setPermission] = useState<NotificationPermission>(
     notificationsSupported ? Notification.permission : 'default'
   );
+  const [showInstallPrompt, setShowInstallPrompt] = useState(false);
 
   useEffect(() => {
     if (!disabled || endTime === null) {
@@ -89,6 +96,14 @@ export const ReminderTimer = ({disabled, minutes, onExpire, storageKey}: Reminde
     const end = Date.now() + minutes * 60 * 1000;
     localStorage.setItem(storageKey, String(end));
     setEndTime(end);
+    if (shouldSuggestInstall() && localStorage.getItem(installPromptDismissedKey) !== 'true') {
+      setShowInstallPrompt(true);
+    }
+  };
+
+  const dismissInstallPrompt = () => {
+    localStorage.setItem(installPromptDismissedKey, 'true');
+    setShowInstallPrompt(false);
   };
 
   const cancel = () => {
@@ -103,20 +118,21 @@ export const ReminderTimer = ({disabled, minutes, onExpire, storageKey}: Reminde
     return null;
   }
 
-  if (endTime !== null && remaining !== null && !disabled) {
-    return (
-      <div className="reminder-timer reminder-timer--active">
-        <span>🕐 Noch {labelForRemaining(remaining)}</span>
-        <button className="reminder-cancel" onClick={cancel}>
-          Abbrechen
-        </button>
-      </div>
-    );
-  }
-
   return (
-    <button className="reminder-timer" onClick={startTimer} disabled={disabled}>
-      🕐 Erinnere mich in {labelForMinutes(minutes)}
-    </button>
+    <>
+      {endTime !== null && remaining !== null && !disabled ? (
+        <div className="reminder-timer reminder-timer--active">
+          <span>🕐 Noch {labelForRemaining(remaining)}</span>
+          <button className="reminder-cancel" onClick={cancel}>
+            Abbrechen
+          </button>
+        </div>
+      ) : (
+        <button className="reminder-timer" onClick={startTimer} disabled={disabled}>
+          🕐 Erinnere mich in {labelForMinutes(minutes)}
+        </button>
+      )}
+      {showInstallPrompt && <InstallPrompt onClose={dismissInstallPrompt} />}
+    </>
   );
 };

--- a/src/index.css
+++ b/src/index.css
@@ -326,6 +326,111 @@ li.checked .checklist-label span {
   color: var(--color-accent);
 }
 
+.install-prompt-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+  padding: 16px;
+  background-color: rgba(0, 0, 0, 0.5);
+  backdrop-filter: blur(2px);
+  animation: install-prompt-fade 0.2s ease-out;
+}
+
+.install-prompt {
+  width: 100%;
+  max-width: 380px;
+  margin-bottom: max(16px, env(safe-area-inset-bottom));
+  padding: 28px 24px 24px;
+  background-color: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: 18px;
+  box-shadow: 0 18px 48px rgba(0, 0, 0, 0.28);
+  text-align: center;
+  animation: install-prompt-rise 0.25s cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+
+.install-prompt-icon {
+  width: 56px;
+  height: 56px;
+  border-radius: 14px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.18);
+}
+
+.install-prompt-title {
+  margin: 16px 0 8px;
+  font-size: 1.2rem;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  color: var(--color-text);
+}
+
+.install-prompt-text {
+  margin: 0 0 18px;
+  font-size: 0.92rem;
+  color: var(--color-text-muted);
+}
+
+.install-prompt-steps {
+  margin: 0 0 22px;
+  padding-left: 1.3em;
+  text-align: left;
+  font-size: 0.92rem;
+  color: var(--color-text);
+}
+
+.install-prompt-steps li {
+  margin-bottom: 0.5em;
+}
+
+.install-prompt-steps li:last-child {
+  margin-bottom: 0;
+}
+
+.install-prompt-share-icon {
+  vertical-align: -4px;
+  color: var(--color-accent);
+}
+
+.install-prompt-close {
+  width: 100%;
+  padding: 12px 16px;
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: #ffffff;
+  background-color: var(--color-accent);
+  border: none;
+  border-radius: 10px;
+  cursor: pointer;
+  transition: filter 0.15s;
+}
+
+.install-prompt-close:hover {
+  filter: brightness(1.08);
+}
+
+@keyframes install-prompt-fade {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes install-prompt-rise {
+  from {
+    opacity: 0;
+    transform: translateY(24px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
 .footer {
   margin-top: 56px;
   padding-top: 20px;

--- a/src/iosPwa.ts
+++ b/src/iosPwa.ts
@@ -1,0 +1,16 @@
+export const isIos = (): boolean => {
+  const ua = window.navigator.userAgent;
+  const isIosDevice = /iphone|ipad|ipod/i.test(ua);
+  // iPadOS 13+ reports a desktop user agent, so fall back to touch detection.
+  const isIpadOs = navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1;
+  return isIosDevice || isIpadOs;
+};
+
+export const isStandalone = (): boolean => {
+  const standalone = (window.navigator as {standalone?: boolean} & Navigator).standalone;
+  return standalone === true || window.matchMedia('(display-mode: standalone)').matches;
+};
+
+// iOS Safari outside the installed PWA has no Notification API, so suggest
+// installing to the Home Screen where timer notifications do work (iOS 16.4+).
+export const shouldSuggestInstall = (): boolean => typeof Notification === 'undefined' && isIos() && !isStandalone();


### PR DESCRIPTION
Add web app manifest icons, scope, and Apple touch icon / web-app meta
tags so the app can be installed to the iOS Home Screen, where timer
notifications work (iOS 16.4+).

When a non-installed iOS Safari user starts a reminder timer, show a
dismissible install hint explaining how to add the app to the Home
Screen for notifications. The timer keeps running as an in-app
countdown in the meantime.