### PR TITLE
fix: show timer notifications via service worker for iOS Safari

### DIFF
--- a/packages/backend/src/push/push.service.ts
+++ b/packages/backend/src/push/push.service.ts
@@ -14,11 +14,20 @@ export class PushService {
     @InjectModel(ScheduledNotification.name)
     private readonly model: Model<ScheduledNotificationDocument>
   ) {
+    if (!VAPID_PUBLIC_KEY || !VAPID_PRIVATE_KEY) {
+      this.logger.error('VAPID keys are not configured; push notifications will not be sent');
+      return;
+    }
     webpush.setVapidDetails(VAPID_SUBJECT, VAPID_PUBLIC_KEY, VAPID_PRIVATE_KEY);
   }
 
   async cancel(id: string): Promise<void> {
-    await this.model.findByIdAndDelete(id);
+    const deleted = await this.model.findByIdAndDelete(id);
+    if (deleted) {
+      this.logger.log(`Cancelled scheduled push ${id}`);
+    } else {
+      this.logger.warn(`Cancel requested for unknown push ${id}`);
+    }
   }
 
   async schedule(
@@ -33,11 +42,17 @@ export class PushService {
       label,
       p256dh: subscription.keys.p256dh,
     });
-    return (doc._id as Types.ObjectId).toString();
+    const id = (doc._id as Types.ObjectId).toString();
+    this.logger.log(`Scheduled push ${id} for ${expiresAt.toISOString()}`);
+    return id;
   }
 
   async sendDue(): Promise<void> {
     const due = await this.model.find({expiresAt: {$lte: new Date()}, sent: false});
+    if (due.length === 0) {
+      return;
+    }
+    this.logger.log(`Sending ${due.length} due push notification(s)`);
 
     for (const doc of due) {
       try {
@@ -48,12 +63,17 @@ export class PushService {
             title: 'Sauerteig-Erinnerung',
           })
         );
+        this.logger.log(`Sent push ${String(doc._id)}`);
         await this.model.findByIdAndDelete(doc._id);
       } catch (error) {
         const statusCode = (error as {statusCode?: number}).statusCode;
-        this.logger.error(`Failed to send push for ${String(doc._id)}: ${String(error)}`);
+        const body = (error as {body?: string}).body;
+        this.logger.error(
+          `Failed to send push for ${String(doc._id)} (status ${String(statusCode)}): ${String(error)}${body ? ` - ${body}` : ''}`
+        );
         if (statusCode === 404 || statusCode === 410) {
           await this.model.findByIdAndDelete(doc._id);
+          this.logger.warn(`Removed expired subscription ${String(doc._id)}`);
         }
       }
     }

--- a/packages/frontend/src/ReminderTimer.tsx
+++ b/packages/frontend/src/ReminderTimer.tsx
@@ -112,6 +112,26 @@ async function cancelBackendNotification(timerId: string): Promise<void> {
   }
 }
 
+// iOS Safari does not support the Notification constructor (it throws a
+// TypeError), so notifications must be shown through the service worker
+// registration. Prefer it everywhere and only fall back to the constructor
+// when no service worker is available.
+async function showLocalNotification(body: string): Promise<void> {
+  if (!notificationsSupported || Notification.permission !== 'granted') {
+    return;
+  }
+  if (pushSupported) {
+    try {
+      const registration = await navigator.serviceWorker.ready;
+      await registration.showNotification('Sauerteig-Erinnerung', {body});
+      return;
+    } catch {
+      // fall back to the constructor below
+    }
+  }
+  new Notification('Sauerteig-Erinnerung', {body});
+}
+
 export const ReminderTimer = ({disabled, minutes, onExpire, storageKey}: ReminderTimerProps) => {
   const timerIdKey = `${storageKey}_timerId`;
 
@@ -155,12 +175,8 @@ export const ReminderTimer = ({disabled, minutes, onExpire, storageKey}: Reminde
     const tick = () => {
       const diff = endTime - Date.now();
       if (diff <= 0) {
-        // Show local notification when the app is open, then cancel the server-side push.
-        if (notificationsSupported && Notification.permission === 'granted') {
-          new Notification('Sauerteig-Erinnerung', {
-            body: `Die Wartezeit von ${labelForMinutes(minutes)} ist abgelaufen!`,
-          });
-        }
+        // Show a local notification when the app is open, then cancel the server-side push.
+        void showLocalNotification(`Die Wartezeit von ${labelForMinutes(minutes)} ist abgelaufen!`);
         clearTimer();
         onExpire?.();
       } else {

--- a/packages/frontend/src/ReminderTimer.tsx
+++ b/packages/frontend/src/ReminderTimer.tsx
@@ -147,6 +147,7 @@ export const ReminderTimer = ({disabled, minutes, onExpire, storageKey}: Reminde
   const [installDismissed, setInstallDismissed] = useState(
     () => window.localStorage.getItem(installPromptDismissedKey) === 'true'
   );
+  const [backendUnreachable, setBackendUnreachable] = useState(false);
 
   const clearTimer = useCallback(() => {
     const timerId = window.localStorage.getItem(timerIdKey);
@@ -157,6 +158,7 @@ export const ReminderTimer = ({disabled, minutes, onExpire, storageKey}: Reminde
     window.localStorage.removeItem(storageKey);
     setEndTime(null);
     setRemaining(null);
+    setBackendUnreachable(false);
   }, [storageKey, timerIdKey]);
 
   useEffect(() => {
@@ -207,6 +209,9 @@ export const ReminderTimer = ({disabled, minutes, onExpire, storageKey}: Reminde
       const timerId = await scheduleBackendNotification(subscription, end, labelForMinutes(minutes));
       if (timerId) {
         window.localStorage.setItem(timerIdKey, timerId);
+        setBackendUnreachable(false);
+      } else {
+        setBackendUnreachable(true);
       }
     }
 
@@ -253,6 +258,11 @@ export const ReminderTimer = ({disabled, minutes, onExpire, storageKey}: Reminde
           </button>
         )}
       </span>
+      {endTime !== null && backendUnreachable && (
+        <span className="reminder-warning" role="alert">
+          ⚠️ Server nicht erreichbar - die Erinnerung im Hintergrund ist nicht aktiv.
+        </span>
+      )}
       {showInstallPrompt && <InstallPrompt onClose={dismissInstallPrompt} />}
     </>
   );

--- a/packages/frontend/src/__tests__/ReminderTimer.test.tsx
+++ b/packages/frontend/src/__tests__/ReminderTimer.test.tsx
@@ -120,4 +120,28 @@ describe('ReminderTimer', () => {
     await act(async () => {});
     expect(vi.mocked(fetch)).toHaveBeenCalledWith(expect.stringContaining('/push/schedule'), expect.any(Object));
   });
+
+  it('shows the expiry notification via the service worker (iOS-safe)', async () => {
+    MockNotification.permission = 'granted';
+    const registration = (await navigator.serviceWorker.ready) as unknown as {
+      showNotification: ReturnType<typeof vi.fn>;
+    };
+    render(<ReminderTimer minutes={1} storageKey="test-timer" />);
+    await startTimer(1);
+    await act(async () => {
+      vi.advanceTimersByTime(60_000);
+    });
+    expect(registration.showNotification).toHaveBeenCalledWith(
+      'Sauerteig-Erinnerung',
+      expect.objectContaining({body: expect.stringContaining('abgelaufen')})
+    );
+  });
+
+  it('warns when the backend cannot be reached', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({ok: false} as Response);
+    render(<ReminderTimer minutes={5} storageKey="test-timer" />);
+    await startTimer();
+    await act(async () => {});
+    expect(screen.getByText(/nicht erreichbar/i)).toBeInTheDocument();
+  });
 });

--- a/packages/frontend/src/__tests__/setup.ts
+++ b/packages/frontend/src/__tests__/setup.ts
@@ -70,6 +70,7 @@ Object.defineProperty(navigator, 'serviceWorker', {
           toJSON: () => ({endpoint: 'https://push.example.com', keys: {auth: 'auth', p256dh: 'p256dh'}}),
         }),
       },
+      showNotification: vi.fn().mockResolvedValue(undefined),
     }),
   },
 });

--- a/packages/frontend/src/index.css
+++ b/packages/frontend/src/index.css
@@ -348,6 +348,13 @@ li.checked .checklist-label span {
   color: var(--color-accent);
 }
 
+.reminder-warning {
+  display: block;
+  margin-top: 6px;
+  font-size: 0.8rem;
+  color: var(--color-accent);
+}
+
 .install-prompt-overlay {
   position: fixed;
   inset: 0;


### PR DESCRIPTION
The foreground expiry path used the Notification constructor, which throws
a TypeError on iOS Safari (notifications must be shown through the service
worker registration). Route notifications through
ServiceWorkerRegistration.showNotification() when a service worker is
available, falling back to the constructor only when it is not.