### PR TITLE
fix: stop Docker build from clobbering frontend push env vars

### DIFF
--- a/frontend.Dockerfile
+++ b/frontend.Dockerfile
@@ -3,14 +3,16 @@ FROM node:26.2.0-alpine@sha256:7c6af15abe4e3de859690e7db171d0d711bf37d27528eddfe
 
 ARG VERSION
 ARG COMMIT
-ARG VITE_BACKEND_URL
-ARG VITE_VAPID_PUBLIC_KEY
 
 ENV NPM_CONFIG_UPDATE_NOTIFIER=false
-ENV VITE_BACKEND_URL=$VITE_BACKEND_URL
 ENV VITE_COMMIT_ID=$COMMIT
 ENV VITE_VERSION=$VERSION
-ENV VITE_VAPID_PUBLIC_KEY=$VITE_VAPID_PUBLIC_KEY
+
+# VITE_BACKEND_URL and VITE_VAPID_PUBLIC_KEY are non-secret and committed in
+# packages/frontend/.env.production. They are intentionally not passed as build
+# args here: an empty build arg would override the .env.production value (Vite
+# lets process.env take precedence), shipping an empty VAPID key and silently
+# breaking push subscriptions.
 
 WORKDIR /app
 


### PR DESCRIPTION
## Problem

Background push notifications never arrived in the installed iOS PWA. The timer notification only fired when the app was brought to the foreground (the in-app `tick`), and the backend logged no error because nothing was ever scheduled.

## Root cause

`frontend.Dockerfile` declared `VITE_BACKEND_URL` and `VITE_VAPID_PUBLIC_KEY` as build args and exported them as `ENV`:

```dockerfile
ARG VITE_VAPID_PUBLIC_KEY
ENV VITE_VAPID_PUBLIC_KEY=$VITE_VAPID_PUBLIC_KEY
```

CI (`main.yml` -> `docker-image-release`) passes **no build args**, so both resolved to **empty strings**. Vite gives `process.env` precedence over `.env.production`, so the empty value won and the production bundle shipped with an **empty VAPID public key**.

With an empty key, `getPushSubscription()` returns early at its `if (!VAPID_PUBLIC_KEY)` guard, so the app never subscribes to push and never calls `POST /push/schedule`. Nothing is scheduled -> the backend has nothing to send -> no log, no error. The only notification that can fire is the in-app one when the app is foregrounded, which is exactly the observed behavior.

## Fix

`VITE_BACKEND_URL` and `VITE_VAPID_PUBLIC_KEY` are non-secret (a VAPID *public* key and a public URL) and are already committed in `packages/frontend/.env.production`. Drop the build args/ENV so Vite reads them from the env file instead of having them clobbered to empty.

## Verification

Local production build (`yarn workspace sauerteig-frontend build`) now bakes the real VAPID key and backend URL into the bundle. After deploy, starting a timer in the home-screen PWA should produce `Scheduled push ...` in the backend logs immediately and `Sent push ...` at expiry, delivering the notification while the app is backgrounded.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Dj9UrR898s9uoQTuYzGWGy)_