### PR TITLE
fix: avoid duplicate reminder notification after background expiry

### DIFF
--- a/packages/frontend/src/ReminderTimer.tsx
+++ b/packages/frontend/src/ReminderTimer.tsx
@@ -15,6 +15,11 @@ const pushSupported = 'serviceWorker' in navigator && 'PushManager' in window;
 // Once dismissed, do not nag the user with the install hint on every timer.
 const installPromptDismissedKey = 'SauerteigInstallPromptDismissed';
 
+// An on-time expiry (app open) is detected within one tick. A larger gap means
+// the app was backgrounded across the expiry, so the backend push already
+// delivered the notification and the local one would be a duplicate.
+const onTimeExpiryToleranceMs = 2000;
+
 interface ReminderTimerProps {
   disabled?: boolean;
   minutes: number;
@@ -149,17 +154,22 @@ export const ReminderTimer = ({disabled, minutes, onExpire, storageKey}: Reminde
   );
   const [backendUnreachable, setBackendUnreachable] = useState(false);
 
-  const clearTimer = useCallback(() => {
-    const timerId = window.localStorage.getItem(timerIdKey);
-    if (timerId) {
-      cancelBackendNotification(timerId);
-      window.localStorage.removeItem(timerIdKey);
-    }
-    window.localStorage.removeItem(storageKey);
-    setEndTime(null);
-    setRemaining(null);
-    setBackendUnreachable(false);
-  }, [storageKey, timerIdKey]);
+  const clearTimer = useCallback(
+    (cancelBackend = true) => {
+      const timerId = window.localStorage.getItem(timerIdKey);
+      if (timerId) {
+        if (cancelBackend) {
+          cancelBackendNotification(timerId);
+        }
+        window.localStorage.removeItem(timerIdKey);
+      }
+      window.localStorage.removeItem(storageKey);
+      setEndTime(null);
+      setRemaining(null);
+      setBackendUnreachable(false);
+    },
+    [storageKey, timerIdKey]
+  );
 
   useEffect(() => {
     if (!disabled || endTime === null) {
@@ -176,14 +186,21 @@ export const ReminderTimer = ({disabled, minutes, onExpire, storageKey}: Reminde
 
     const tick = () => {
       const diff = endTime - Date.now();
-      if (diff <= 0) {
-        // Show a local notification when the app is open, then cancel the server-side push.
+      if (diff > 0) {
+        setRemaining(diff);
+        return;
+      }
+      // If a backend push was scheduled and the timer expired while the app was
+      // backgrounded, the server push already showed the notification. Clear the
+      // local state but leave the push in place instead of showing a duplicate.
+      const scheduledBackend = window.localStorage.getItem(timerIdKey) !== null;
+      if (scheduledBackend && Date.now() - endTime > onTimeExpiryToleranceMs) {
+        clearTimer(false);
+      } else {
         void showLocalNotification(`Die Wartezeit von ${labelForMinutes(minutes)} ist abgelaufen!`);
         clearTimer();
-        onExpire?.();
-      } else {
-        setRemaining(diff);
       }
+      onExpire?.();
     };
 
     const immediateId = setTimeout(tick, 0);
@@ -193,7 +210,7 @@ export const ReminderTimer = ({disabled, minutes, onExpire, storageKey}: Reminde
       clearTimeout(immediateId);
       clearInterval(intervalId);
     };
-  }, [endTime, clearTimer, minutes, onExpire, disabled]);
+  }, [endTime, clearTimer, minutes, onExpire, disabled, timerIdKey]);
 
   const startTimer = async () => {
     if (notificationsSupported && permission === 'default') {
@@ -238,7 +255,7 @@ export const ReminderTimer = ({disabled, minutes, onExpire, storageKey}: Reminde
         {endTime !== null && remaining !== null && !disabled ? (
           <div className="reminder-timer reminder-timer--active">
             <span>🕐 Noch {labelForRemaining(remaining)}</span>
-            <button className="reminder-cancel" onClick={clearTimer}>
+            <button className="reminder-cancel" onClick={() => clearTimer()}>
               Abbrechen
             </button>
           </div>

--- a/packages/frontend/src/__tests__/ReminderTimer.test.tsx
+++ b/packages/frontend/src/__tests__/ReminderTimer.test.tsx
@@ -137,6 +137,27 @@ describe('ReminderTimer', () => {
     );
   });
 
+  it('does not show a duplicate local notification when the timer expired in the background', async () => {
+    MockNotification.permission = 'granted';
+    const registration = (await navigator.serviceWorker.ready) as unknown as {
+      showNotification: ReturnType<typeof vi.fn>;
+    };
+    // Timer expired 10s ago while the app was backgrounded, with a backend push scheduled.
+    window.localStorage.setItem('test-timer', String(Date.now() - 10_000));
+    window.localStorage.setItem('test-timer_timerId', 'mock-timer-id');
+    render(<ReminderTimer minutes={5} storageKey="test-timer" />);
+    await act(async () => {
+      vi.advanceTimersByTime(0);
+    });
+    expect(registration.showNotification).not.toHaveBeenCalled();
+    // Local state is cleared, but the backend push is not cancelled.
+    expect(window.localStorage.getItem('test-timer')).toBeNull();
+    expect(vi.mocked(fetch)).not.toHaveBeenCalledWith(
+      expect.stringContaining('/push/schedule/'),
+      expect.objectContaining({method: 'DELETE'})
+    );
+  });
+
   it('warns when the backend cannot be reached', async () => {
     vi.mocked(fetch).mockResolvedValueOnce({ok: false} as Response);
     render(<ReminderTimer minutes={5} storageKey="test-timer" />);


### PR DESCRIPTION
## Problem

Now that background push works, the reminder notification arrives **twice** on iOS.

## Cause

There are two notification sources:
- **Background:** the backend Web Push fires while the PWA is closed/backgrounded.
- **Foreground:** the in-app `tick` shows a local notification when it detects the timer has expired.

When the timer expires while the PWA is backgrounded, the backend push delivers the notification (#1). When the user then opens the app, the `tick` runs, sees the already-expired timer, and fires a second identical local notification (#2). Because the push is usually what prompts the user to open the app, the two land seconds apart and read as a duplicate.

(The existing cancel logic only prevents the backend push when the local timer fires *first*, i.e. while the app is open the whole time, so it doesn't cover this case.)

## Fix

Distinguish an **on-time** expiry (app open, detected within one tick) from a **stale** expiry (detected after the app was backgrounded across the expiry):

- On-time expiry: show the local notification and cancel the backend push (unchanged).
- Stale expiry with a backend push scheduled: skip the local notification and leave the backend push in place as the single source.

A `clearTimer(cancelBackend = false)` variant clears local state without cancelling the server-side push.

## Tests

Added a test that a stale background expiry with a scheduled push shows no local notification and does not cancel the backend push. All 86 frontend tests pass; lint and build are clean.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Dj9UrR898s9uoQTuYzGWGy)_