### PR TITLE
fix: make ingredient checkboxes non-sequential

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,16 +108,17 @@ packages/
     src/
       index.tsx             # entry point (React StrictMode)
       App.tsx               # root component, wraps with SauerteigProvider
-      Content.tsx           # main layout: navigation, theme toggle, step display
+      Content.tsx           # main layout: navigation, theme toggle, step display, progress bar
       Introduction.tsx      # step 0 - table of contents and ingredient overview
       Step.tsx              # displays a single recipe step with reminder timers
       ReminderTimer.tsx     # countdown timer with browser notification on expiry
+      ProgressBar.tsx       # thin bar above the navigation showing cumulative step progress
       SauerteigContext.ts   # React Context definition for the current step
       SauerteigProvider.tsx # Context provider (current step persisted to localStorage)
       data.ts               # recipe data: 6 steps, ingredients, timings
       index.css             # global styles with CSS custom properties for theming
       references.d.ts       # Vite client type references
-      __tests__/            # vitest test suite (83 tests, >=80% coverage)
+      __tests__/            # vitest test suite (96 tests, >=80% coverage)
     public/
       img/                  # bread logo in sizes 16-512px + SVG
       manifest.json         # PWA manifest
@@ -141,8 +142,10 @@ Rezept.md                   # the full recipe as plain text
 ## Key Architecture Decisions
 
 - **State management**: React Context (`SauerteigContext`) for the current step; no external state library.
-- **Persistence**: `localStorage` keys - `SauerteigStep` (current step), `SauerteigTheme` (light/dark preference), plus one key per reminder timer storing its expiry timestamp.
+- **Persistence**: `localStorage` keys - `SauerteigStep` (current step), `SauerteigTheme` (light/dark preference), `SauerteigStep_<stepItemId>` (one per preparation step, `'true'`/`'false'`), `SauerteigIngredients_<stepId>` (JSON boolean array per page), plus one `SauerteigTimer_<stepItemId>` per reminder timer storing its expiry timestamp.
 - **Reminder timers**: `ReminderTimer` lets the user start a countdown for a waiting period. The expiry timestamp is stored in `localStorage` so the countdown survives reloads, and a browser `Notification` fires when it expires (requires notification permission). The backend schedules a fallback push notification via Web Push for when the app is not open.
+- **Progress bar**: `ProgressBar` is a thin bar rendered above the navigation buttons. `Content` derives a cumulative fraction from `localStorage` (checked preparation steps across all pages divided by the total number of preparation steps), so it advances across pages and does not reset when navigating. `Step` reports changes through an `onStepsChange` callback that triggers a recount. Ingredient checkboxes do not count toward progress.
+- **Checklists**: preparation steps (Zubereitung) are sequential - a step is only checkable once every step above it is checked, and unchecking a step clears the steps below it (the checked items stay a contiguous prefix). Ingredient checkboxes (Zutaten on step pages and the intro's "Benötigt werden" list) are independent and checkable in any order.
 - **Theme**: CSS custom properties on `:root[data-theme]`. System preference detected via `prefers-color-scheme`; user override persisted to `localStorage`.
 - **Navigation**: keyboard (arrow keys), swipe gestures (`react-swipeable`), and on-screen buttons all supported.
 - **Deployment**: each package is built into its own Docker image (`frontend.Dockerfile`, `backend.Dockerfile`) and deployed to Coolify by the CI workflow. Frontend is served from the site root, so assets use relative paths.

--- a/packages/frontend/src/Introduction.tsx
+++ b/packages/frontend/src/Introduction.tsx
@@ -2,21 +2,13 @@ import {useState, useContext} from 'react';
 import {introductionData, stepsData} from './data';
 import {SauerteigContext} from './SauerteigContext';
 
-// A checkbox can only be toggled once every box above it is checked.
-const isUnlocked = (checked: boolean[], index: number) => checked.slice(0, index).every(Boolean);
-
 export const Introduction = () => {
   const {setCurrentStep} = useContext(SauerteigContext);
   const {ingredients, title} = introductionData;
   const [checkedIngredients, setCheckedIngredients] = useState<boolean[]>(() => ingredients.map(() => false));
 
-  // The intro only lists ingredients, which do not count toward progress.
-  const toggleIngredient = (index: number) => {
-    setCheckedIngredients(prev => {
-      const willCheck = !prev[index];
-      return prev.map((v, i) => (willCheck ? v || i <= index : v && i < index));
-    });
-  };
+  // The intro only lists ingredients, which are not sequential and do not count toward progress.
+  const toggleIngredient = (index: number) => setCheckedIngredients(prev => prev.map((v, i) => (i === index ? !v : v)));
 
   return (
     <div className="part">
@@ -39,12 +31,7 @@ export const Introduction = () => {
         {ingredients.map((ingredient, index) => (
           <li key={index} className={checkedIngredients[index] ? 'checked' : ''}>
             <label className="checklist-label">
-              <input
-                type="checkbox"
-                checked={checkedIngredients[index]}
-                disabled={!isUnlocked(checkedIngredients, index)}
-                onChange={() => toggleIngredient(index)}
-              />
+              <input type="checkbox" checked={checkedIngredients[index]} onChange={() => toggleIngredient(index)} />
               <span>{ingredient}</span>
             </label>
           </li>

--- a/packages/frontend/src/Step.tsx
+++ b/packages/frontend/src/Step.tsx
@@ -10,7 +10,7 @@ export interface StepProps {
   stepNumber: number;
 }
 
-// A checkbox can only be toggled once every box above it is checked.
+// A preparation step can only be toggled once every step above it is checked.
 const isUnlocked = (checked: boolean[], index: number) => checked.slice(0, index).every(Boolean);
 
 export const Step = ({onStepsChange, stepNumber}: StepProps) => {
@@ -72,8 +72,7 @@ export const Step = ({onStepsChange, stepNumber}: StepProps) => {
 
   const toggleIngredient = (index: number) => {
     setCheckedIngredients(prev => {
-      const willCheck = !prev[index];
-      const next = prev.map((v, i) => (willCheck ? v || i <= index : v && i < index));
+      const next = prev.map((v, i) => (i === index ? !v : v));
       window.localStorage.setItem(`SauerteigIngredients_${stepId}`, JSON.stringify(next));
       return next;
     });
@@ -98,12 +97,7 @@ export const Step = ({onStepsChange, stepNumber}: StepProps) => {
             {ingredients.map((ingredient, index) => (
               <li key={index} className={checkedIngredients[index] ? 'checked' : ''}>
                 <label className="checklist-label">
-                  <input
-                    type="checkbox"
-                    checked={checkedIngredients[index]}
-                    disabled={!isUnlocked(checkedIngredients, index)}
-                    onChange={() => toggleIngredient(index)}
-                  />
+                  <input type="checkbox" checked={checkedIngredients[index]} onChange={() => toggleIngredient(index)} />
                   <span>{ingredient}</span>
                 </label>
               </li>

--- a/packages/frontend/src/__tests__/Introduction.test.tsx
+++ b/packages/frontend/src/__tests__/Introduction.test.tsx
@@ -46,6 +46,15 @@ describe('Introduction', () => {
     expect(checkboxes[0]).toBeChecked();
   });
 
+  it('allows checking ingredients in any order', () => {
+    renderWithContext();
+    const checkboxes = screen.getAllByRole('checkbox');
+    expect(checkboxes[2]).toBeEnabled();
+    fireEvent.click(checkboxes[2]);
+    expect(checkboxes[2]).toBeChecked();
+    expect(checkboxes[0]).not.toBeChecked();
+  });
+
   it('toggling a checked checkbox unchecks it', () => {
     renderWithContext();
     const checkboxes = screen.getAllByRole('checkbox');

--- a/packages/frontend/src/__tests__/Step.test.tsx
+++ b/packages/frontend/src/__tests__/Step.test.tsx
@@ -150,6 +150,16 @@ describe('Step', () => {
     expect(onStepsChange).toHaveBeenCalled();
   });
 
+  it('allows checking ingredients in any order', () => {
+    render(<Step stepNumber={stepWithIngredients} />);
+    const checkboxes = screen.getAllByRole('checkbox');
+    // The second ingredient is enabled and checkable without the first.
+    expect(checkboxes[1]).toBeEnabled();
+    fireEvent.click(checkboxes[1]);
+    expect(checkboxes[1]).toBeChecked();
+    expect(checkboxes[0]).not.toBeChecked();
+  });
+
   it('disables a preparation step until the previous one is checked', () => {
     render(<Step stepNumber={1} />);
     const ingredientCount = stepsData[0].ingredients.length;


### PR DESCRIPTION
## Summary

Ingredient checkboxes should not be sequential. Sequential gating now applies **only to the "Zubereitung" preparation steps**. The ingredient checkboxes under "Zutaten" (step pages) and "Benötigt werden" (intro) are always checkable, in any order.

## Changes

- **`Step.tsx`**: reverted the "Zutaten" ingredient toggle to a plain independent toggle; removed the `disabled` gating from ingredient checkboxes. Preparation steps keep their sequential gating and cascade-on-uncheck.
- **`Introduction.tsx`**: reverted the "Benötigt werden" ingredient toggle to a plain independent toggle; removed the now-unused sequential helper and `disabled` attribute.
- **`AGENTS.md`**: documented the progress bar (cumulative, above the navigation) and the checklist behavior (steps sequential, ingredients independent), refreshed the file list and frontend test count.

## Testing

- `yarn test` (frontend): 96 passed, including new tests asserting ingredients can be checked in any order in both `Step` and `Introduction`.
- `yarn fix` and `yarn build`: clean.